### PR TITLE
feat: add swap module

### DIFF
--- a/modules/nixos/facter.nix
+++ b/modules/nixos/facter.nix
@@ -14,6 +14,7 @@ in
     ./networking
     ./virtualisation.nix
     ./firmware.nix
+    ./swap.nix
     ./system.nix
   ];
 

--- a/modules/nixos/swap.nix
+++ b/modules/nixos/swap.nix
@@ -1,0 +1,30 @@
+{ lib, config, ... }:
+let
+  inherit (config.facter) report;
+
+in
+{
+  options.facter.swap.enable = lib.mkEnableOption "Enable the Facter Swap module" // {
+    default = lib.length (report.swap or [ ]) > 0;
+    defaultText = "enabled if there are swap entries in the report";
+  };
+
+  # generate the swapDevices option from the swap devices that were active when the report was captured
+  config = lib.mkIf config.facter.swap.enable {
+    swapDevices =
+      let
+        # we only take swap partitions that are not zram devices
+        # https://github.com/NixOS/nixpkgs/blob/dac9cdf8c930c0af98a63cbfe8005546ba0125fb/nixos/modules/installer/tools/nixos-generate-config.pl#L335-L357
+        swapPartitions = lib.filter (
+          { filename, type, ... }: type == "partition" && !(lib.hasPrefix "/dev/zram" filename)
+        ) report.swap;
+      in
+      map (
+        { filename, ... }:
+        {
+          device = filename;
+        }
+      ) swapPartitions;
+  };
+
+}


### PR DESCRIPTION
Configures `swapDevices` based on the active swap partitions when the report was captured.

Intended to match the behaviour of `nixos-generate-config` https://github.com/NixOS/nixpkgs/blob/dac9cdf8c930c0af98a63cbfe8005546ba0125fb/nixos/modules/installer/tools/nixos-generate-config.pl#L335-L357
