### PR TITLE
feat: add report version check to modules

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 { inputs, ... }:
 let
-  facterLib = import ./lib.nix inputs.nixpkgs.lib;
+  inherit (inputs.nixpkgs) lib;
+  facterLib = import ./lib.nix lib;
 in
-facterLib // { tests = import ./lib.tests.nix facterLib; }
+facterLib // { tests = import ./lib.tests.nix { inherit lib facterLib; }; }

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -17,10 +17,23 @@ let
       device: device.hardware_class == "cpu" && device.detail.vendor_name == "GenuineIntel"
     ) hardware;
 
+  checkReportVersion =
+    {
+      min ? 1,
+      max ? null,
+    }:
+    report@{
+      version ? 1,
+      ...
+    }:
+    lib.throwIfNot (min <= version && (max == null || version <= max))
+      "nixos-facter report version ${toString version} is unsupported: min = ${toString min}, max = ${toString max}"
+      report;
+
 in
 {
   inherit isAllOf isOneOf canonicalSort;
-  inherit hasAmdCpu hasIntelCpu;
+  inherit hasAmdCpu hasIntelCpu checkReportVersion;
 
   isMassStorageController =
     {

--- a/lib/lib.tests.nix
+++ b/lib/lib.tests.nix
@@ -1,4 +1,4 @@
-facterLib:
+{ facterLib, ... }:
 let
   usbController = {
     base_class = {
@@ -15,6 +15,59 @@ let
 in
 with facterLib;
 {
+  reportVersion =
+    let
+      mkReport = version: {
+        inherit version;
+        virtualisation = "kvm";
+        hardware = [ ];
+        smbios = [ ];
+      };
+    in
+    {
+      testMin =
+        let
+          report = mkReport 4;
+        in
+        {
+          expr = checkReportVersion { min = 4; } report;
+          expected = report;
+        };
+      testMinFailure =
+        let
+          report = mkReport 4;
+        in
+        {
+          expr = checkReportVersion { min = 5; } report;
+          expectedError = {
+            type = "ThrownError";
+            msg = "nixos-facter report version 4 is unsupported: min = 5, max =";
+          };
+        };
+      testMax =
+        let
+          report = mkReport 25;
+        in
+        {
+          expr = checkReportVersion { max = 25; } report;
+          expected = report;
+        };
+      testMaxFailure =
+        let
+          report = mkReport 25;
+        in
+        {
+          expr = checkReportVersion {
+            min = 10;
+            max = 24;
+          } report;
+          expectedError = {
+            type = "ThrownError";
+            msg = "nixos-facter report version 25 is unsupported: min = 10, max = 24";
+          };
+        };
+    };
+
   testIsMassStorageController = {
     expr = map isMassStorageController [
       { }

--- a/modules/nixos/boot.nix
+++ b/modules/nixos/boot.nix
@@ -1,9 +1,9 @@
 { lib, config, ... }:
 let
   facterLib = import ../../lib/lib.nix lib;
+  report = facterLib.checkReportVersion { max = 1; } config.facter.report;
 
   cfg = config.facter.boot;
-  inherit (config.facter) report;
 in
 {
   options.facter.boot.enable = lib.mkEnableOption "Enable the Facter Boot module" // {

--- a/modules/nixos/firmware.nix
+++ b/modules/nixos/firmware.nix
@@ -1,8 +1,8 @@
 { lib, config, ... }:
 let
   facterLib = import ../../lib/lib.nix lib;
+  report = facterLib.checkReportVersion { max = 1; } config.facter.report;
 
-  inherit (config.facter) report;
   isBaremetal = config.facter.virtualisation.none.enable;
   hasAmdCpu = facterLib.hasAmdCpu report;
   hasIntelCpu = facterLib.hasIntelCpu report;

--- a/modules/nixos/networking/broadcom.nix
+++ b/modules/nixos/networking/broadcom.nix
@@ -1,8 +1,8 @@
 { lib, config, ... }:
 let
   facterLib = import ../../../lib/lib.nix lib;
+  report = facterLib.checkReportVersion { max = 1; } config.facter.report;
 
-  inherit (config.facter) report;
   cfg = config.facter.networking.broadcom;
 in
 {

--- a/modules/nixos/networking/intel.nix
+++ b/modules/nixos/networking/intel.nix
@@ -1,8 +1,8 @@
 { lib, config, ... }:
 let
   facterLib = import ../../../lib/lib.nix lib;
+  report = facterLib.checkReportVersion { max = 1; } config.facter.report;
 
-  inherit (config.facter) report;
   cfg = config.facter.networking.intel;
 in
 {

--- a/modules/nixos/virtualisation.nix
+++ b/modules/nixos/virtualisation.nix
@@ -6,8 +6,8 @@
 }:
 let
   facterLib = import ../../lib/lib.nix lib;
+  report = facterLib.checkReportVersion { max = 1; } config.facter.report;
 
-  inherit (config.facter) report;
   cfg = config.facter.virtualisation;
 in
 {


### PR DESCRIPTION
Introduces a new lib function for enforcing a version range for reports.

Also adds a max v1 check to existing modules, in preparation for the structural changes about to land with v2. This should ensure existing users (e.g. Mic92 currently) get a nice error message if they try to use an incompatible report version.

Going forward, modules should enforce a minimum/maximum report version they support.
