### PR TITLE
Chore: Improve downstream usabillity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ that part of the configuration yourself or take it from `nixos-generate-config`.
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-facter-modules.url = "github:numtide/nixos-facter-modules";
+    nixos-facter-modules.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =

--- a/dev/private.narHash
+++ b/dev/private.narHash
@@ -1,0 +1,1 @@
+sha256-6tFlF8x+M46Ub7IiBb/DsPoThzsyFvbnYF+0iq8mUvo=

--- a/dev/private/flake.lock
+++ b/dev/private/flake.lock
@@ -1,0 +1,46 @@
+{
+  "nodes": {
+    "nixpkgs-dev": {
+      "locked": {
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs-dev": "nixpkgs-dev",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": []
+      },
+      "locked": {
+        "lastModified": 1724338379,
+        "narHash": "sha256-kKJtaiU5Ou+e/0Qs7SICXF22DLx4V/WhG1P6+k4yeOE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "070f834771efa715f3e74cd8ab93ecc96fabc951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/private/flake.nix
+++ b/dev/private/flake.nix
@@ -1,0 +1,10 @@
+{
+  description = "private inputs";
+  # Follow the same nixpkgs as the main flake
+  inputs.nixpkgs-dev.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+  inputs.treefmt-nix.inputs.nixpkgs.follows = "";
+
+  outputs = _: { };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,5 @@
 {
   "nodes": {
-    "blueprint": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": [
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1722503414,
-        "narHash": "sha256-JFMBd4cERlKd2lH1FuWgiwf2Q9PzPRPsdD4HV8Fs2IQ=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "214500b4802d1e0149a51aa19340d6f1aefb33e8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1723637854,
@@ -41,45 +18,7 @@
     },
     "root": {
       "inputs": {
-        "blueprint": "blueprint",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1723656612,
-        "narHash": "sha256-6Sx+/VhRPLR+kRf6rnNUFMQ66DUz1DMYajixYUe+CUU=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "4a6d7dccf80a1aa2d04cfaa88d9e5511542a2486",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,35 +5,95 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs: let
-    inherit (inputs.nixpkgs) lib;
+  outputs =
+    publicInputs@{
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      inherit (publicInputs.nixpkgs) lib;
 
-    findTests = path:
-      with lib;
-        filterAttrsRecursive (_n: v: v != {}) (
-          mapAttrs' (
-            n: v:
-              if (v == "regular" && (hasSuffix ".unit.nix" n))
-              then nameValuePair n (import "${path}/${n}" lib)
-              else if v == "directory"
-              then nameValuePair n (findTests "${path}/${n}")
-              else nameValuePair n {}
-          ) (builtins.readDir path)
+      loadPrivateFlake =
+        path:
+        let
+          flakeHash = nixpkgs.lib.fileContents "${toString path}.narHash";
+          flakePath = "path:${toString path}?narHash=${flakeHash}";
+        in
+        builtins.getFlake (builtins.unsafeDiscardStringContext flakePath);
+
+      privateFlake = loadPrivateFlake ./dev/private;
+
+      privateInputs = privateFlake.inputs;
+
+      inputs = publicInputs;
+
+      systems = [
+        "aarch64-linux"
+        "riscv64-linux"
+        "x86_64-linux"
+      ];
+      eachSystem =
+        f:
+        builtins.listToAttrs (
+          builtins.map (system: {
+            name = system;
+            value = f {
+              pkgs = import nixpkgs { inherit system; };
+              inherit system;
+            };
+          }) systems
         );
-  in {
-    lib = import ./lib { inherit inputs; };
+    in
+    {
+      lib = import ./lib { inherit inputs; };
 
-    nixosConfigurations = {
-      basic = (import ./hosts/basic { inherit inputs; flake = inputs.self; }).value;
-    };
-    nixosModules = {
-      boot = ./modules/nixos/boot.nix;
-      facter = ./modules/nixos/facter.nix;
-      firmware = ./modules/nixos/firmware.nix;
-      networking = ./modules/nixos/networking;
-      system = ./modules/nixos/system.nix;
-      virtualisation = ./modules/nixos/virtualisation.nix;
-    };
-    unit-tests = findTests ./.;
-  };
+      nixosConfigurations = {
+        basic =
+          (import ./hosts/basic {
+            inherit inputs;
+            flake = inputs.self;
+          }).value;
+      };
+      nixosModules = {
+        boot = ./modules/nixos/boot.nix;
+        facter = ./modules/nixos/facter.nix;
+        firmware = ./modules/nixos/firmware.nix;
+        networking = ./modules/nixos/networking;
+        system = ./modules/nixos/system.nix;
+        virtualisation = ./modules/nixos/virtualisation.nix;
+      };
+    }
+    //
+      # DevOutputs
+      {
+        devShells = eachSystem (
+          { pkgs, ... }:
+          {
+            default = pkgs.callPackage ./devshell.nix { };
+          }
+        );
+        formatter = eachSystem ({ pkgs, ... }: pkgs.callPackage ./formatter.nix { inputs = inputs // privateInputs; });
+
+        checks = eachSystem (
+          { pkgs, ... }:
+          {
+            lib-tests = pkgs.runCommandLocal "lib-tests" { nativeBuildInputs = [ pkgs.nix-unit ]; } ''
+              export HOME="$(realpath .)"
+              export NIX_CONFIG='
+              extra-experimental-features = nix-command flakes
+              flake-registry = ""
+              '
+
+              nix-unit --flake ${inputs.self}#lib.tests ${
+                toString (
+                  lib.mapAttrsToList (k: v: "--override-input ${k} ${v}") (builtins.removeAttrs inputs [ "self" ])
+                )
+              }
+
+              touch $out
+            '';
+          }
+        );
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,50 +3,37 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    systems.url = "github:nix-systems/default";
-    blueprint = {
-      url = "github:numtide/blueprint";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-    };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs =
-    inputs:
-    inputs.blueprint {
-      inherit inputs;
-      systems = [
-        "aarch64-linux"
-        "riscv64-linux"
-        "x86_64-linux"
-      ];
-    }
-    // (
-      let
-        inherit (inputs.nixpkgs) lib;
+  outputs = inputs: let
+    inherit (inputs.nixpkgs) lib;
 
-        findTests =
-          path:
-          with lib;
-          filterAttrsRecursive (_n: v: v != { }) (
-            mapAttrs' (
-              n: v:
-              if (v == "regular" && (hasSuffix ".unit.nix" n)) then
-                nameValuePair n (import "${path}/${n}" lib)
-              else if v == "directory" then
-                nameValuePair n (findTests "${path}/${n}")
-              else
-                nameValuePair n { }
-            ) (builtins.readDir path)
-          );
-      in
-      {
-        # you can run all the tests from a devshell with `nix-unit --flake .#unit-tests` or `nix build .#unit-tests`
-        unit-tests = findTests ./.;
-      }
-    );
+    findTests = path:
+      with lib;
+        filterAttrsRecursive (_n: v: v != {}) (
+          mapAttrs' (
+            n: v:
+              if (v == "regular" && (hasSuffix ".unit.nix" n))
+              then nameValuePair n (import "${path}/${n}" lib)
+              else if v == "directory"
+              then nameValuePair n (findTests "${path}/${n}")
+              else nameValuePair n {}
+          ) (builtins.readDir path)
+        );
+  in {
+    lib = import ./lib { inherit inputs; };
+
+    nixosConfigurations = {
+      basic = (import ./hosts/basic { inherit inputs; flake = inputs.self; }).value;
+    };
+    nixosModules = {
+      boot = ./modules/nixos/boot.nix;
+      facter = ./modules/nixos/facter.nix;
+      firmware = ./modules/nixos/firmware.nix;
+      networking = ./modules/nixos/networking;
+      system = ./modules/nixos/system.nix;
+      virtualisation = ./modules/nixos/virtualisation.nix;
+    };
+    unit-tests = findTests ./.;
+  };
 }


### PR DESCRIPTION
Remove all dependencies.

Dev and check dependencies can be added back in a seperate flake.nix:

Like in:
- https://github.com/ipetkov/crane/tree/master/test
- https://github.com/nix-community/srvos/tree/main/dev/private

When using this flake properly in a third party library currently the following expression is needed:

```nix
inputs = {
....
    systems.url = "github:nix-systems/default";
    treefmt-nix.url = "github:numtide/treefmt-nix";
    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";

    nixos-facter-modules.url = "github:numtide/nixos-facter-modules";
    nixos-facter-modules.inputs.nixpkgs.follows = "nixpkgs";

    nixos-facter-modules.inputs.systems.follows = "systems";
    nixos-facter-modules.inputs.blueprint.follows = "blueprint";
    nixos-facter-modules.inputs.treefmt-nix.follows = "treefmt-nix";

    blueprint.url = "github:numtide/blueprint";
    blueprint.inputs.nixpkgs.follows = "nixpkgs";
    blueprint.inputs.systems.follows = "systems";
}
```

> NOTE: I MUST override every single input and add transitive inputs to the toplevel of the flake. Otherwise my own downstream users cannot use `follow`. Every new layer MUST add their own dependencies, which accumulates really fast.

see:  https://github.com/NixOS/nix/issues/5790

After this PR:

```nix
inputs = {
....
    nixos-facter-modules.url = "github:numtide/nixos-facter-modules";
    nixos-facter-modules.inputs.nixpkgs.follows = "nixpkgs";
}
```

