### PR TITLE
Avoid duplicating modules in the list of initrd modules

### DIFF
--- a/modules/nixos/boot.nix
+++ b/modules/nixos/boot.nix
@@ -13,16 +13,16 @@ in
     with lib;
     mkIf cfg.enable {
       boot.initrd.availableKernelModules = filter (dm: dm != null) (
-        map
-          (
-            {
-              driver_module ? null,
-              ...
-            }:
-            driver_module
-          )
-          (
-            unique (flatten [
+        unique (
+          map
+            (
+              {
+                driver_module ? null,
+                ...
+              }:
+              driver_module
+            )
+            (flatten [
               # Needed if we want to use the keyboard when things go wrong in the initrd.
               (report.hardware.usb_controller or [ ])
               # A disk might be attached.
@@ -31,7 +31,7 @@ in
               (report.hardware.disk or [ ])
               (report.hardware.storage_controller or [ ])
             ])
-          )
+        )
       );
     };
 }


### PR DESCRIPTION
Functionally this doesn't change anything as they get deduplicated during the initrd build anyway, but when inspecting values in the repl or running nix-diff, it's kind of ugly to see the same module repeated 4 times.
It also makes it harder to check the diffs (only after this change, it became clear to me that I was missing two modules after removing my old hardware config).
