### PR TITLE
move all hardware detection to its own namespace

### DIFF
--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -1,8 +1,8 @@
 { lib, config, ... }:
 {
-  options.facter.bluetooth.enable = lib.mkEnableOption "Enable the Facter bluetooth module" // {
+  options.facter.detected.bluetooth.enable = lib.mkEnableOption "Enable the Facter bluetooth module" // {
     default = builtins.length (config.facter.report.hardware.bluetooth or []) > 0;
   };
 
-  config.hardware.bluetooth.enable = lib.mkIf config.facter.bluetooth.enable (lib.mkDefault true);
+  config.hardware.bluetooth.enable = lib.mkIf config.facter.detected.bluetooth.enable (lib.mkDefault true);
 }

--- a/modules/nixos/boot.nix
+++ b/modules/nixos/boot.nix
@@ -2,11 +2,11 @@
 let
   facterLib = import ../../lib/lib.nix lib;
 
-  cfg = config.facter.boot;
+  cfg = config.facter.detected.boot;
   inherit (config.facter) report;
 in
 {
-  options.facter.boot.enable = lib.mkEnableOption "Enable the Facter Boot module" // {
+  options.facter.detected.boot.enable = lib.mkEnableOption "Enable the Facter Boot module" // {
     default = true;
   };
 

--- a/modules/nixos/disk.nix
+++ b/modules/nixos/disk.nix
@@ -2,23 +2,20 @@
 let
   facterLib = import ../../lib/lib.nix lib;
 
-  cfg = config.facter.detected.boot;
+  cfg = config.facter.detected.boot.disk;
   inherit (config.facter) report;
 in
 {
-  options.facter.detected.boot.enable = lib.mkEnableOption "Enable the Facter Boot module" // {
+  options.facter.detected.boot.disk.enable = lib.mkEnableOption "Enable Disk drivers in initrd" // {
     default = true;
   };
 
   config =
-    with lib;
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
       boot.initrd.availableKernelModules = facterLib.stringSet (
         facterLib.collectDrivers (
-          # Needed if we want to use the keyboard when things go wrong in the initrd.
-          (report.hardware.usb_controller or [ ])
           # A disk might be attached.
-          ++ (report.hardware.firewire_controller or [ ])
+          (report.hardware.firewire_controller or [ ])
           # definitely important
           ++ (report.hardware.disk or [ ])
           ++ (report.hardware.storage_controller or [ ])

--- a/modules/nixos/disk.nix
+++ b/modules/nixos/disk.nix
@@ -2,17 +2,12 @@
 let
   facterLib = import ../../lib/lib.nix lib;
 
-  cfg = config.facter.detected.boot.disk;
   inherit (config.facter) report;
 in
 {
-  options.facter.detected.boot.disk.enable = lib.mkEnableOption "Enable Disk drivers in initrd" // {
-    default = true;
-  };
-
-  config =
-    lib.mkIf cfg.enable {
-      boot.initrd.availableKernelModules = facterLib.stringSet (
+  options.facter.detected.boot.disk.kernelModules = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = facterLib.stringSet (
         facterLib.collectDrivers (
           # A disk might be attached.
           (report.hardware.firewire_controller or [ ])
@@ -21,5 +16,12 @@ in
           ++ (report.hardware.storage_controller or [ ])
         )
       );
-    };
+    description = ''
+      List of kernel modules that are needed to access the disk.
+    '';
+  };
+
+  config = {
+    boot.initrd.availableKernelModules = config.facter.detected.boot.disk.kernelModules;
+  };
 }

--- a/modules/nixos/facter.nix
+++ b/modules/nixos/facter.nix
@@ -11,7 +11,8 @@ in
 {
   imports = [
     ./bluetooth.nix
-    ./boot.nix
+    ./disk.nix
+    ./keyboard.nix
     ./firmware.nix
     ./graphics.nix
     ./networking

--- a/modules/nixos/firmware.nix
+++ b/modules/nixos/firmware.nix
@@ -3,7 +3,7 @@ let
   facterLib = import ../../lib/lib.nix lib;
 
   inherit (config.facter) report;
-  isBaremetal = config.facter.virtualisation.none.enable;
+  isBaremetal = config.facter.detected.virtualisation.none.enable;
   hasAmdCpu = facterLib.hasAmdCpu report;
   hasIntelCpu = facterLib.hasIntelCpu report;
 in

--- a/modules/nixos/graphics.nix
+++ b/modules/nixos/graphics.nix
@@ -1,16 +1,28 @@
 { lib, config, ... }:
 let
   facterLib = import ../../lib/lib.nix lib;
+  cfg = config.facter.detected.graphics;
 in
 {
-  options.facter.detected.graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
-    default = builtins.length (config.facter.report.hardware.monitor or [ ]) > 0;
+  options.facter.detected = {
+    graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
+      default = builtins.length (config.facter.report.hardware.monitor or [ ]) > 0;
+    };
+    boot.graphics.kernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      # We currently don't auto import nouveau, in case the user might want to use the proprietary nvidia driver,
+      # We might want to change this in future, if we have a better idea, how to handle this.
+      default = lib.remove "nouveau" (
+        facterLib.stringSet (facterLib.collectDrivers (config.facter.report.hardware.graphics_card or [ ]))
+      );
+      description = ''
+        List of kernel modules to load at boot for the graphics card.
+      '';
+    };
   };
 
-  config = lib.mkIf config.facter.detected.graphics.enable {
+  config = lib.mkIf cfg.enable {
     hardware.graphics.enable = lib.mkDefault true;
-    boot.initrd.kernelModules = facterLib.stringSet (
-      facterLib.collectDrivers (config.facter.report.hardware.graphics_card or [ ])
-    );
+    boot.initrd.kernelModules = config.facter.detected.boot.graphics.kernelModules;
   };
 }

--- a/modules/nixos/graphics.nix
+++ b/modules/nixos/graphics.nix
@@ -3,11 +3,11 @@ let
   facterLib = import ../../lib/lib.nix lib;
 in
 {
-  options.facter.graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
+  options.facter.detected.graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
     default = builtins.length (config.facter.report.hardware.monitor or [ ]) > 0;
   };
 
-  config = lib.mkIf config.facter.graphics.enable {
+  config = lib.mkIf config.facter.detected.graphics.enable {
     hardware.graphics.enable = lib.mkDefault true;
     boot.initrd.kernelModules = facterLib.stringSet (
       facterLib.collectDrivers (config.facter.report.hardware.graphics_card or [ ])

--- a/modules/nixos/keyboard.nix
+++ b/modules/nixos/keyboard.nix
@@ -1,0 +1,22 @@
+{ lib, config, ... }:
+let
+  facterLib = import ../../lib/lib.nix lib;
+
+  cfg = config.facter.detected.boot.keyboard;
+  inherit (config.facter) report;
+in
+{
+  options.facter.detected.boot.keyboard.enable =
+    lib.mkEnableOption "Enable Keyboard support in the initrd"
+    // {
+      default = true;
+    };
+
+  config =
+    lib.mkIf cfg.enable {
+      boot.initrd.availableKernelModules = facterLib.stringSet (
+        # Needed if we want to use the keyboard when things go wrong in the initrd.
+        facterLib.collectDrivers (report.hardware.usb_controller or [ ])
+      );
+    };
+}

--- a/modules/nixos/keyboard.nix
+++ b/modules/nixos/keyboard.nix
@@ -2,21 +2,19 @@
 let
   facterLib = import ../../lib/lib.nix lib;
 
-  cfg = config.facter.detected.boot.keyboard;
   inherit (config.facter) report;
 in
 {
-  options.facter.detected.boot.keyboard.enable =
-    lib.mkEnableOption "Enable Keyboard support in the initrd"
-    // {
-      default = true;
-    };
+  options.facter.detected.boot.keyboard.kernelModules = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = facterLib.collectDrivers (report.hardware.usb_controller or [ ]);
+    example = [ "usbhid" ];
+    description = ''
+      List of kernel modules to include in the initrd to support the keyboard.
+    '';
+  };
 
-  config =
-    lib.mkIf cfg.enable {
-      boot.initrd.availableKernelModules = facterLib.stringSet (
-        # Needed if we want to use the keyboard when things go wrong in the initrd.
-        facterLib.collectDrivers (report.hardware.usb_controller or [ ])
-      );
-    };
+  config = {
+    boot.initrd.availableKernelModules = config.facter.detected.boot.keyboard.kernelModules;
+  };
 }

--- a/modules/nixos/networking/broadcom.nix
+++ b/modules/nixos/networking/broadcom.nix
@@ -1,10 +1,10 @@
 { lib, config, ... }:
 let
   inherit (config.facter) report;
-  cfg = config.facter.networking.broadcom;
+  cfg = config.facter.detected.networking.broadcom;
 in
 {
-  options.facter.networking.broadcom = with lib; {
+  options.facter.detected.networking.broadcom = with lib; {
     full_mac.enable = mkEnableOption "Enable the Facter Broadcom Full MAC module" // {
 
       default = lib.any (

--- a/modules/nixos/networking/intel.nix
+++ b/modules/nixos/networking/intel.nix
@@ -1,10 +1,10 @@
 { lib, config, ... }:
 let
   inherit (config.facter) report;
-  cfg = config.facter.networking.intel;
+  cfg = config.facter.detected.networking.intel;
 in
 {
-  options.facter.networking.intel = with lib; {
+  options.facter.detected.networking.intel = with lib; {
     _2200BG.enable = mkEnableOption "Enable the Facter Intel 2200BG module" // {
 
       default = lib.any (

--- a/modules/nixos/virtualisation.nix
+++ b/modules/nixos/virtualisation.nix
@@ -6,10 +6,10 @@
 }:
 let
   inherit (config.facter) report;
-  cfg = config.facter.virtualisation;
+  cfg = config.facter.detected.virtualisation;
 in
 {
-  options.facter.virtualisation = {
+  options.facter.detected.virtualisation = {
     virtio_scsi.enable = lib.mkEnableOption "Enable the Facter Virtualisation Virtio SCSI module" // {
       default = lib.any (
         { vendor, device, ... }:


### PR DESCRIPTION
This allows us to debug things easier in the repl by using the :p option.
Also makes generating options documentation easier because we can distinguish between general option and detected hardware options.