### PR TITLE
virtualisation: Make parallels handling more lazy

### DIFF
--- a/modules/nixos/virtualisation.nix
+++ b/modules/nixos/virtualisation.nix
@@ -97,10 +97,8 @@ in
 
     # parallels
     hardware.parallels.enable = lib.mkIf cfg.parallels.enable (lib.mkDefault true);
-    nixpkgs.config = lib.mkIf (!options.nixpkgs.pkgs.isDefined) {
-      allowUnfreePredicate = lib.mkIf cfg.parallels.enable (
-        pkg: builtins.elem (lib.getName pkg) [ "prl-tools" ]
-      );
+    nixpkgs.config = lib.mkIf (!options.nixpkgs.pkgs.isDefined && cfg.parallels.enable) {
+      allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "prl-tools" ];
     };
   };
 }


### PR DESCRIPTION
Moves the condition to allow parallels as an unfree module up one level.
This is required for users who don't instantiate their own nixpkgs
instance which causes `options.nixpkgs.pkgs.isDefined` being false.
In this case, although `cfg.parallels.enable` is false, the
`allowUnfreePredicate` will still be set resulting an error complaining
about `allowUnfreePredicate` option being used but not defined.
