### PR TITLE
networking: Add default value for DHCP

### DIFF
--- a/modules/nixos/networking/default.nix
+++ b/modules/nixos/networking/default.nix
@@ -1,6 +1,10 @@
+{ config, lib, ... }:
 {
   imports = [
     ./broadcom.nix
     ./intel.nix
   ];
+  config.networking = lib.mkIf (builtins.length (config.facter.report.network_interface or [ ]) > 0) {
+    useDHCP = lib.mkDefault true;
+  };
 }


### PR DESCRIPTION
Replicates the behavior of nixos-generate-config which is to configure
`useDCHP` to default to true if there are more than 0 network
interfaces.

See https://github.com/NixOS/nixpkgs/blob/f59db697ef71a9cbebd11cc81d87d184866382ff/nixos/modules/installer/tools/nixos-generate-config.pl#L608
