### PR TITLE
docs: add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # nixos-facter-modules
 
+> [!WARNING]
+> **This repository is deprecated.** The modules have been upstreamed to nixpkgs.
+> Please use the nixpkgs version instead:
+>
+> ```nix
+> {
+>   hardware.facter.report = ./facter.json;
+> }
+> ```
+>
+> See the [nixpkgs documentation](https://search.nixos.org/options?query=facter) for more details.
+
+---
+
 A series of [NixOS modules] to be used in conjunction with [NixOS Facter].
 
 With a similar goal to [NixOS Hardware], these modules are designed around _fine-grained_ feature detection as opposed to system models.


### PR DESCRIPTION
## Summary

- Add deprecation warning to README pointing users to the nixpkgs implementation

The modules have been upstreamed to nixpkgs and this repository is no longer actively maintained.

Closes #99